### PR TITLE
Bump librdkafka to 2.3.0 with zstd compression support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:20.04
 
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl-dev zlib1g-dev gcc g++ make git ca-certificates \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl-dev zlib1g-dev libzstd-dev libsasl2-dev gcc g++ make git ca-certificates  \
   && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/edenhill/librdkafka
+RUN git clone https://github.com/confluentinc/librdkafka
 WORKDIR /librdkafka
 ARG LIBRDKAFKA_VERSION
 RUN git checkout tags/v${LIBRDKAFKA_VERSION}
+RUN ./configure --install-deps
 RUN ./configure --prefix=/librdkafka_arm
 RUN make
 RUN make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:20.04
 
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl-dev zlib1g-dev libzstd-dev libsasl2-dev gcc g++ make git ca-certificates  \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libssl-dev zlib1g-dev libzstd-dev liblz4-dev rapidjson-dev libsasl2-dev libcurl4-openssl-dev gcc g++ make git ca-certificates python3 wget curl build-essential \
+  && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/confluentinc/librdkafka
@@ -9,7 +10,7 @@ WORKDIR /librdkafka
 ARG LIBRDKAFKA_VERSION
 RUN git checkout tags/v${LIBRDKAFKA_VERSION}
 RUN ./configure --install-deps
-RUN ./configure --prefix=/librdkafka_arm
+RUN STATIC_LIB_libzstd=/usr/lib/aarch64-linux-gnu/libzstd.a ./configure --enable-static --prefix=/librdkafka_arm
 RUN make
 RUN make install
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build extract_files
 
 build:
-	docker build --progress plain --platform linux/arm64 --build-arg LIBRDKAFKA_VERSION=1.7.0 -t local/kafka-arm-binary .
+	docker build --progress plain --platform linux/arm64 --build-arg LIBRDKAFKA_VERSION=2.3.0 -t local/kafka-arm-binary .
 
 extract_files: build
 	mkdir binary_files || true


### PR DESCRIPTION
This bumps `librdkafka` to 2.3.0 for ARM and adds `zstd` support.

I tried to use the [recommended installation method](https://github.com/confluentinc/confluent-kafka-python/blob/master/INSTALL.md#install-pre-built-wheels-recommended) which includes a binary wheel with `librdkafka` but it couldn't make it work. It could find `librdkafka-dev` files.

Error:
```
# In an ubuntu:20.04 container
root@1889c1b7883c:~# apt update && apt install python3 python3-pip -y
root@1889c1b7883c:~# python3 -m pip install confluent-kafka==2.3.0
Collecting confluent-kafka
  Downloading confluent-kafka-2.3.0.tar.gz (134 kB)
     |████████████████████████████████| 134 kB 2.8 MB/s 
Building wheels for collected packages: confluent-kafka
  Building wheel for confluent-kafka (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-g350km54
       cwd: /tmp/pip-install-vpu_uzlg/confluent-kafka/
  Complete output (65 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-aarch64-3.8
  creating build/lib.linux-aarch64-3.8/confluent_kafka
  copying src/confluent_kafka/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka
  copying src/confluent_kafka/deserializing_consumer.py -> build/lib.linux-aarch64-3.8/confluent_kafka
  copying src/confluent_kafka/serializing_producer.py -> build/lib.linux-aarch64-3.8/confluent_kafka
  copying src/confluent_kafka/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka
  creating build/lib.linux-aarch64-3.8/confluent_kafka/_util
  copying src/confluent_kafka/_util/validation_util.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
  copying src/confluent_kafka/_util/conversion_util.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
  copying src/confluent_kafka/_util/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
  creating build/lib.linux-aarch64-3.8/confluent_kafka/avro
  copying src/confluent_kafka/avro/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
  copying src/confluent_kafka/avro/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
  copying src/confluent_kafka/avro/cached_schema_registry_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
  copying src/confluent_kafka/avro/load.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
  creating build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/schema_registry_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/avro.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/json_schema.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  copying src/confluent_kafka/schema_registry/protobuf.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
  creating build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_resource.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_acl.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_group.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_config.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_scram.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_topic.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_metadata.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_cluster.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  copying src/confluent_kafka/admin/_listoffsets.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
  creating build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
  copying src/confluent_kafka/kafkatest/verifiable_consumer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
  copying src/confluent_kafka/kafkatest/verifiable_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
  copying src/confluent_kafka/kafkatest/verifiable_producer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
  copying src/confluent_kafka/kafkatest/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
  creating build/lib.linux-aarch64-3.8/confluent_kafka/serialization
  copying src/confluent_kafka/serialization/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/serialization
  creating build/lib.linux-aarch64-3.8/confluent_kafka/_model
  copying src/confluent_kafka/_model/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_model
  creating build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
  copying src/confluent_kafka/avro/serializer/message_serializer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
  copying src/confluent_kafka/avro/serializer/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
  running build_ext
  building 'confluent_kafka.cimpl' extension
  creating build/temp.linux-aarch64-3.8
  creating build/temp.linux-aarch64-3.8/tmp
  creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg
  creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka
  creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src
  creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka
  creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src
  aarch64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.8 -c /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c -o build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.o
  In file included from /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c:17:
  /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.h:23:10: fatal error: librdkafka/rdkafka.h: No such file or directory
     23 | #include <librdkafka/rdkafka.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  error: command 'aarch64-linux-gnu-gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for confluent-kafka
  Running setup.py clean for confluent-kafka
Failed to build confluent-kafka
Installing collected packages: confluent-kafka
    Running setup.py install for confluent-kafka ... error
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8p226_gq/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.8/confluent-kafka
         cwd: /tmp/pip-install-vpu_uzlg/confluent-kafka/
    Complete output (65 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-aarch64-3.8
    creating build/lib.linux-aarch64-3.8/confluent_kafka
    copying src/confluent_kafka/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka
    copying src/confluent_kafka/deserializing_consumer.py -> build/lib.linux-aarch64-3.8/confluent_kafka
    copying src/confluent_kafka/serializing_producer.py -> build/lib.linux-aarch64-3.8/confluent_kafka
    copying src/confluent_kafka/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka
    creating build/lib.linux-aarch64-3.8/confluent_kafka/_util
    copying src/confluent_kafka/_util/validation_util.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
    copying src/confluent_kafka/_util/conversion_util.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
    copying src/confluent_kafka/_util/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_util
    creating build/lib.linux-aarch64-3.8/confluent_kafka/avro
    copying src/confluent_kafka/avro/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
    copying src/confluent_kafka/avro/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
    copying src/confluent_kafka/avro/cached_schema_registry_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
    copying src/confluent_kafka/avro/load.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro
    creating build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/schema_registry_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/error.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/avro.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/json_schema.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    copying src/confluent_kafka/schema_registry/protobuf.py -> build/lib.linux-aarch64-3.8/confluent_kafka/schema_registry
    creating build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_resource.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_acl.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_group.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_config.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_scram.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_topic.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_metadata.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_cluster.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    copying src/confluent_kafka/admin/_listoffsets.py -> build/lib.linux-aarch64-3.8/confluent_kafka/admin
    creating build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
    copying src/confluent_kafka/kafkatest/verifiable_consumer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
    copying src/confluent_kafka/kafkatest/verifiable_client.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
    copying src/confluent_kafka/kafkatest/verifiable_producer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
    copying src/confluent_kafka/kafkatest/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/kafkatest
    creating build/lib.linux-aarch64-3.8/confluent_kafka/serialization
    copying src/confluent_kafka/serialization/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/serialization
    creating build/lib.linux-aarch64-3.8/confluent_kafka/_model
    copying src/confluent_kafka/_model/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/_model
    creating build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
    copying src/confluent_kafka/avro/serializer/message_serializer.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
    copying src/confluent_kafka/avro/serializer/__init__.py -> build/lib.linux-aarch64-3.8/confluent_kafka/avro/serializer
    running build_ext
    building 'confluent_kafka.cimpl' extension
    creating build/temp.linux-aarch64-3.8
    creating build/temp.linux-aarch64-3.8/tmp
    creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg
    creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka
    creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src
    creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka
    creating build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src
    aarch64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.8 -c /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c -o build/temp.linux-aarch64-3.8/tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.o
    In file included from /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.c:17:
    /tmp/pip-install-vpu_uzlg/confluent-kafka/src/confluent_kafka/src/confluent_kafka.h:23:10: fatal error: librdkafka/rdkafka.h: No such file or directory
       23 | #include <librdkafka/rdkafka.h>
          |          ^~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    error: command 'aarch64-linux-gnu-gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"'; __file__='"'"'/tmp/pip-install-vpu_uzlg/confluent-kafka/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8p226_gq/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.8/confluent-kafka Check the logs for full command output.
```

Relates to https://github.com/closeio/closeio-infrastructure/issues/4134